### PR TITLE
Ajout des tests unitaires pour le projet

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package initialization

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,93 @@
+"""Configuration fixtures for pytest."""
+
+import os
+import tempfile
+import pytest
+import pandas as pd
+import numpy as np
+
+@pytest.fixture
+def sample_price_data():
+    """Generate sample price data for testing."""
+    index = pd.date_range(start='2023-01-01', end='2023-12-31', freq='B')
+    tickers = ['AAPL', 'MSFT', 'GOOGL', 'AMZN', 'META']
+    
+    np.random.seed(42)  # For reproducibility
+    
+    data = {}
+    for ticker in tickers:
+        # Generate random price movements
+        prices = 100 + np.cumsum(np.random.normal(0.001, 0.02, len(index)))
+        data[ticker] = prices
+    
+    df = pd.DataFrame(data, index=index)
+    return df
+
+@pytest.fixture
+def sample_fundamental_data():
+    """Generate sample fundamental data for testing."""
+    tickers = ['AAPL', 'MSFT', 'GOOGL', 'AMZN', 'META']
+    
+    data = {
+        'Ticker': tickers,
+        'PE_Ratio': [20.5, 30.2, 25.1, 60.3, 15.8],
+        'PB_Ratio': [15.3, 12.1, 5.2, 14.3, 4.8],
+        'ROE': [0.35, 0.28, 0.22, 0.18, 0.25],
+        'ROA': [0.21, 0.18, 0.15, 0.08, 0.12],
+        'ROIC': [0.25, 0.22, 0.18, 0.12, 0.20],
+        'Profit_Margin': [0.25, 0.35, 0.28, 0.05, 0.32],
+        'Revenue_Growth': [0.15, 0.12, 0.20, 0.30, 0.08],
+        'Earnings_Growth': [0.18, 0.14, 0.22, 0.25, 0.10],
+        'Debt_to_Equity': [0.3, 0.5, 0.2, 0.8, 0.15],
+        'Current_Ratio': [2.5, 1.8, 3.2, 1.5, 2.8],
+        'Interest_Coverage': [25.0, 18.0, 30.0, 10.0, 35.0]
+    }
+    
+    return pd.DataFrame(data).set_index('Ticker')
+
+@pytest.fixture
+def mock_config():
+    """Create a mock configuration for testing."""
+    return {
+        'GENERAL': {
+            'log_level': 'INFO',
+            'data_dir': 'test_data',
+            'results_dir': 'test_data/results'
+        },
+        'SCORING': {
+            'fundamental_weight': 0.7,
+            'technical_weight': 0.2,
+            'quality_weight': 0.1
+        },
+        'FUNDAMENTAL_WEIGHTS': {
+            'PE_Ratio': 0.10,
+            'PB_Ratio': 0.05,
+            'ROE': 0.15,
+            'ROA': 0.10,
+            'ROIC': 0.15,
+            'Profit_Margin': 0.10,
+            'Revenue_Growth': 0.10,
+            'Earnings_Growth': 0.10,
+            'Debt_to_Equity': 0.05,
+            'Current_Ratio': 0.05,
+            'Interest_Coverage': 0.05
+        },
+        'TECHNICAL_WEIGHTS': {
+            'trend_ma': 0.15,
+            'rsi': 0.15,
+            'macd': 0.10,
+            'relative_strength': 0.10
+        },
+        'PORTFOLIO_OPTIMIZATION': {
+            'risk_free_rate': 0.02,
+            'max_weight_per_asset': 0.25,
+            'min_weight_per_asset': 0.01
+        }
+    }
+
+@pytest.fixture
+def temp_data_dir():
+    """Create a temporary directory for test data."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.makedirs(os.path.join(temp_dir, 'results'), exist_ok=True)
+        yield temp_dir

--- a/tests/test_data/__init__.py
+++ b/tests/test_data/__init__.py
@@ -1,0 +1,1 @@
+# Test data module initialization

--- a/tests/test_data/test_collectors.py
+++ b/tests/test_data/test_collectors.py
@@ -1,0 +1,81 @@
+"""Tests for data collectors."""
+
+import pandas as pd
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.data.collectors import YahooFinanceCollector
+
+
+def test_collector_initialization():
+    """Test the initialization of data collectors."""
+    collector = YahooFinanceCollector()
+    assert collector is not None
+    assert hasattr(collector, 'fetch_stock_data')
+
+
+@patch('src.data.collectors.yf.download')
+def test_fetch_stock_data(mock_download, sample_price_data):
+    """Test fetching stock data from Yahoo Finance."""
+    # Setup the mock
+    mock_download.return_value = sample_price_data
+    
+    # Initialize collector
+    collector = YahooFinanceCollector()
+    
+    # Call the method to test
+    result = collector.fetch_stock_data(
+        tickers=['AAPL', 'MSFT', 'GOOGL'],
+        start_date='2023-01-01',
+        end_date='2023-12-31'
+    )
+    
+    # Verify the mock was called correctly
+    mock_download.assert_called_once()
+    
+    # Verify the result is as expected
+    assert isinstance(result, pd.DataFrame)
+    assert not result.empty
+
+
+@patch('src.data.collectors.yf.Ticker')
+def test_fetch_fundamental_data(mock_ticker_class):
+    """Test fetching fundamental data for stocks."""
+    # Setup the mock
+    mock_ticker = MagicMock()
+    mock_ticker.info = {
+        'trailingPE': 25.5,
+        'priceToBook': 12.3,
+        'returnOnEquity': 0.35,
+        'returnOnAssets': 0.22,
+        'profitMargins': 0.28,
+        'revenueGrowth': 0.15,
+        'earningsGrowth': 0.18,
+        'debtToEquity': 0.5,
+        'currentRatio': 2.1,
+        'totalCash': 100000000000,
+        'totalDebt': 50000000000,
+        'totalRevenue': 300000000000,
+        'grossProfits': 150000000000,
+        'ebitda': 80000000000,
+        'operatingCashflow': 75000000000,
+        'freeCashflow': 60000000000
+    }
+    mock_ticker_class.return_value = mock_ticker
+    
+    # Initialize collector
+    collector = YahooFinanceCollector()
+    
+    # Call the method to test
+    result = collector.fetch_fundamental_data('AAPL')
+    
+    # Verify the results
+    assert isinstance(result, dict)
+    assert 'PE_Ratio' in result
+    assert 'PB_Ratio' in result
+    assert 'ROE' in result
+    assert 'ROA' in result
+    assert result['PE_Ratio'] == 25.5
+    assert result['PB_Ratio'] == 12.3
+    assert result['ROE'] == 0.35
+    assert result['ROA'] == 0.22

--- a/tests/test_models/__init__.py
+++ b/tests/test_models/__init__.py
@@ -1,0 +1,1 @@
+# Test models module initialization

--- a/tests/test_models/test_scoring.py
+++ b/tests/test_models/test_scoring.py
@@ -1,0 +1,110 @@
+"""Tests for stock scoring models."""
+
+import pandas as pd
+import numpy as np
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.models.scoring import StockScorer
+
+
+def test_scorer_initialization(mock_config):
+    """Test initialization of the StockScorer class."""
+    scorer = StockScorer(config=mock_config)
+    assert scorer is not None
+    assert hasattr(scorer, 'calculate_fundamental_score')
+    assert hasattr(scorer, 'calculate_technical_score')
+    assert hasattr(scorer, 'calculate_combined_score')
+
+
+def test_calculate_fundamental_score(sample_fundamental_data, mock_config):
+    """Test calculation of fundamental scores."""
+    # Initialize scorer
+    scorer = StockScorer(config=mock_config)
+    
+    # Call the method to test
+    result = scorer.calculate_fundamental_score(sample_fundamental_data)
+    
+    # Verify result structure
+    assert isinstance(result, pd.Series)
+    assert not result.empty
+    assert result.index.equals(sample_fundamental_data.index)
+    
+    # Verify score range
+    assert result.min() >= 0
+    assert result.max() <= 1
+    
+    # Verify relative ranking
+    # Higher ROE and lower P/E should result in better scores
+    assert result['AAPL'] > result['AMZN']  # AAPL has better fundamentals than AMZN in our test data
+
+
+def test_calculate_technical_score(sample_price_data, mock_config):
+    """Test calculation of technical scores."""
+    with patch('src.models.scoring.calculate_rsi'):
+        with patch('src.models.scoring.calculate_macd'):
+            # Initialize scorer
+            scorer = StockScorer(config=mock_config)
+            
+            # Call the method to test
+            result = scorer.calculate_technical_score(
+                price_data=sample_price_data,
+                window=20
+            )
+            
+            # Verify result structure
+            assert isinstance(result, pd.Series)
+            assert not result.empty
+            
+            # Verify score range
+            assert result.min() >= 0
+            assert result.max() <= 1
+
+
+def test_calculate_combined_score(sample_fundamental_data, sample_price_data, mock_config):
+    """Test calculation of combined scores."""
+    with patch.object(StockScorer, 'calculate_fundamental_score') as mock_fund_score:
+        with patch.object(StockScorer, 'calculate_technical_score') as mock_tech_score:
+            # Setup mocks
+            fund_scores = pd.Series({
+                'AAPL': 0.85,
+                'MSFT': 0.82,
+                'GOOGL': 0.75,
+                'AMZN': 0.68,
+                'META': 0.79
+            })
+            tech_scores = pd.Series({
+                'AAPL': 0.75,
+                'MSFT': 0.80,
+                'GOOGL': 0.72,
+                'AMZN': 0.85,
+                'META': 0.65
+            })
+            mock_fund_score.return_value = fund_scores
+            mock_tech_score.return_value = tech_scores
+            
+            # Initialize scorer
+            scorer = StockScorer(config=mock_config)
+            
+            # Call the method to test
+            result = scorer.calculate_combined_score(
+                fundamental_data=sample_fundamental_data,
+                price_data=sample_price_data
+            )
+            
+            # Verify result structure
+            assert isinstance(result, pd.DataFrame)
+            assert not result.empty
+            assert 'Fundamental_Score' in result.columns
+            assert 'Technical_Score' in result.columns
+            assert 'Combined_Score' in result.columns
+            
+            # Verify combined score calculation
+            # Combined score should be weighted average of fund and tech scores
+            expected_combined = fund_scores * 0.7 + tech_scores * 0.2  # weights from mock_config
+            pd.testing.assert_series_equal(
+                result['Combined_Score'],
+                expected_combined,
+                check_exact=False,
+                rtol=1e-2
+            )

--- a/tests/test_visualization/__init__.py
+++ b/tests/test_visualization/__init__.py
@@ -1,0 +1,1 @@
+# Test visualization module initialization

--- a/tests/test_visualization/test_dashboard.py
+++ b/tests/test_visualization/test_dashboard.py
@@ -1,0 +1,168 @@
+"""Tests for visualization dashboard."""
+
+import pandas as pd
+import numpy as np
+import pytest
+from unittest.mock import patch, MagicMock
+import matplotlib.pyplot as plt
+
+from src.visualization.dashboard import PerformanceDashboard
+
+
+@pytest.fixture
+def sample_performance_data():
+    """Generate sample performance data for testing."""
+    index = pd.date_range(start='2023-01-01', end='2023-12-31', freq='B')
+    
+    np.random.seed(42)  # For reproducibility
+    
+    # Portfolio values over time
+    portfolio_value = 1000 * (1 + np.cumsum(np.random.normal(0.001, 0.015, len(index))))
+    
+    # Benchmark values over time (e.g., S&P 500)
+    benchmark_value = 1000 * (1 + np.cumsum(np.random.normal(0.0008, 0.012, len(index))))
+    
+    data = {
+        'Portfolio_Value': portfolio_value,
+        'Benchmark_Value': benchmark_value
+    }
+    
+    return pd.DataFrame(data, index=index)
+
+
+def test_dashboard_initialization(sample_performance_data):
+    """Test initialization of the PerformanceDashboard class."""
+    dashboard = PerformanceDashboard(
+        performance_data=sample_performance_data,
+        portfolio_name='Test Portfolio',
+        benchmark_name='S&P 500'
+    )
+    
+    assert dashboard is not None
+    assert hasattr(dashboard, 'plot_performance')
+    assert hasattr(dashboard, 'plot_drawdown')
+    assert hasattr(dashboard, 'plot_monthly_returns')
+    assert hasattr(dashboard, 'plot_risk_return')
+    assert hasattr(dashboard, 'generate_performance_report')
+
+
+@patch('matplotlib.pyplot.figure')
+@patch('matplotlib.pyplot.savefig')
+def test_plot_performance(mock_savefig, mock_figure, sample_performance_data):
+    """Test plotting portfolio performance."""
+    # Setup mock
+    mock_fig = MagicMock()
+    mock_ax = MagicMock()
+    mock_fig.add_subplot.return_value = mock_ax
+    mock_figure.return_value = mock_fig
+    
+    # Initialize dashboard
+    dashboard = PerformanceDashboard(
+        performance_data=sample_performance_data,
+        portfolio_name='Test Portfolio',
+        benchmark_name='S&P 500'
+    )
+    
+    # Call the method to test
+    dashboard.plot_performance(figsize=(10, 6), save_path='test.png')
+    
+    # Verify plot creation
+    mock_figure.assert_called_once()
+    assert mock_ax.plot.call_count >= 2  # Should plot at least portfolio and benchmark
+    assert mock_ax.legend.call_count >= 1
+    assert mock_ax.set_title.call_count >= 1
+    
+    # Verify save was called if save_path was provided
+    mock_savefig.assert_called_once_with('test.png', dpi=300, bbox_inches='tight')
+
+
+@patch('matplotlib.pyplot.figure')
+def test_plot_drawdown(mock_figure, sample_performance_data):
+    """Test plotting drawdown chart."""
+    # Setup mock
+    mock_fig = MagicMock()
+    mock_ax = MagicMock()
+    mock_fig.add_subplot.return_value = mock_ax
+    mock_figure.return_value = mock_fig
+    
+    # Initialize dashboard
+    dashboard = PerformanceDashboard(
+        performance_data=sample_performance_data,
+        portfolio_name='Test Portfolio',
+        benchmark_name='S&P 500'
+    )
+    
+    # Call the method to test
+    dashboard.plot_drawdown(figsize=(10, 6))
+    
+    # Verify plot creation
+    mock_figure.assert_called_once()
+    assert mock_ax.fill_between.call_count >= 1  # Should create area plot for drawdown
+    assert mock_ax.set_title.call_count >= 1
+    assert mock_ax.set_ylabel.call_count >= 1
+
+
+def test_calculate_performance_metrics(sample_performance_data):
+    """Test calculation of performance metrics."""
+    # Initialize dashboard
+    dashboard = PerformanceDashboard(
+        performance_data=sample_performance_data,
+        portfolio_name='Test Portfolio',
+        benchmark_name='S&P 500'
+    )
+    
+    # Call the method to test
+    metrics = dashboard.calculate_performance_metrics()
+    
+    # Verify metrics structure
+    assert isinstance(metrics, dict)
+    assert 'Portfolio' in metrics
+    assert 'Benchmark' in metrics
+    
+    portfolio_metrics = metrics['Portfolio']
+    benchmark_metrics = metrics['Benchmark']
+    
+    # Verify portfolio metrics
+    assert 'Total Return' in portfolio_metrics
+    assert 'Annualized Return' in portfolio_metrics
+    assert 'Annualized Volatility' in portfolio_metrics
+    assert 'Sharpe Ratio' in portfolio_metrics
+    assert 'Max Drawdown' in portfolio_metrics
+    
+    # Verify benchmark metrics
+    assert 'Total Return' in benchmark_metrics
+    assert 'Annualized Return' in benchmark_metrics
+    assert 'Annualized Volatility' in benchmark_metrics
+    assert 'Sharpe Ratio' in benchmark_metrics
+    assert 'Max Drawdown' in benchmark_metrics
+
+
+@patch('matplotlib.pyplot.figure')
+def test_generate_performance_report(mock_figure, sample_performance_data):
+    """Test generation of performance report with multiple plots."""
+    # Setup mock
+    mock_fig = MagicMock()
+    mock_ax = MagicMock()
+    mock_fig.add_subplot.return_value = mock_ax
+    mock_figure.return_value = mock_fig
+    
+    # Initialize dashboard
+    dashboard = PerformanceDashboard(
+        performance_data=sample_performance_data,
+        portfolio_name='Test Portfolio',
+        benchmark_name='S&P 500'
+    )
+    
+    # Patch individual plot methods
+    with patch.object(dashboard, 'plot_performance') as mock_performance:
+        with patch.object(dashboard, 'plot_drawdown') as mock_drawdown:
+            with patch.object(dashboard, 'plot_monthly_returns') as mock_monthly:
+                with patch.object(dashboard, 'plot_risk_return') as mock_risk:
+                    # Call the method to test
+                    dashboard.generate_performance_report(save_path='test_report.pdf')
+                    
+                    # Verify all plot methods were called
+                    mock_performance.assert_called_once()
+                    mock_drawdown.assert_called_once()
+                    mock_monthly.assert_called_once()
+                    mock_risk.assert_called_once()


### PR DESCRIPTION
Cette PR ajoute la structure de tests unitaires au projet avec :

1. Une structure organisée en modules correspondant à la structure du projet
2. Des fixtures pytest pour faciliter les tests
3. Des tests pour les collecteurs de données (YahooFinanceCollector)
4. Des tests pour les modèles de scoring (StockScorer)
5. Des tests pour l'optimisation de portefeuille (PortfolioOptimizer)
6. Des tests pour le dashboard de visualisation (PerformanceDashboard)

Ces tests permettront de garantir la stabilité du code lors des futures évolutions du projet.